### PR TITLE
orpenWeather/hotfix

### DIFF
--- a/src/weather/weather.resource.ts
+++ b/src/weather/weather.resource.ts
@@ -10,7 +10,7 @@ export class WeatherResource {
 
   @Get('/hello')
   getHello(): string {
-    return JSON.stringify(this.weatherController.getHello());
+    return this.weatherController.getHello();
   }
 
   @Get('/data')
@@ -25,14 +25,14 @@ export class WeatherResource {
       country, city
     )
 
-    return JSON.stringify(weatherResponseDTO)
+    return weatherResponseDTO
   }
 
   @Get('/history')
   public async getHistoryRequests(){
     const weatherResponseDTO = await this.weatherController.getAllDataWeatherRequest()
 
-    return JSON.stringify(weatherResponseDTO)
+    return weatherResponseDTO
   }
 
   @Post('/subscription/webhook')
@@ -42,6 +42,6 @@ export class WeatherResource {
 
     const weatherWebhookDTO = await this.webhookController.registryWeatherWebhook(city.toLowerCase().trim(), country.toLowerCase().trim(), webhook_url.trim())
 
-    return JSON.stringify(weatherWebhookDTO)
+    return weatherWebhookDTO
   }
 }


### PR DESCRIPTION
Removing convertion into code of response to JSON because the framework make this automatically to all responses class, objects and strings :/
At this time all responses are converted to JSON on return resource, but reconverted by the NEST to data != JSON type.
This PR fix this.